### PR TITLE
chore(*): use COREOS lsb-release variables

### DIFF
--- a/scripts/image_signing/ensure_sane_lsb-release.sh
+++ b/scripts/image_signing/ensure_sane_lsb-release.sh
@@ -135,28 +135,28 @@ main() {
   # Basic syntax check first.
   lsb_syntaxcheck "$lsb" || testfail=1
 
-  lsbequals $lsb CHROMEOS_AUSERVER "$expected_auserver" || testfail=1
-  lsbequals $lsb CHROMEOS_RELEASE_NAME "$expected_release_name" || testfail=1
-  check_keyval_in_list $lsb CHROMEOS_RELEASE_TRACK \
+  lsbequals $lsb COREOS_AUSERVER "$expected_auserver" || testfail=1
+  lsbequals $lsb COREOS_RELEASE_NAME "$expected_release_name" || testfail=1
+  check_keyval_in_list $lsb COREOS_RELEASE_TRACK \
     "${expected_release_tracks[@]}" || testfail=1
 
-  if check_keyval_in_list $lsb CHROMEOS_RELEASE_BOARD \
+  if check_keyval_in_list $lsb COREOS_RELEASE_BOARD \
     "${expected_boards[@]}"; then
     # Pick the right set of test-expectation data to use. The cuts
     # turn e.g. x86-foo-pvtkeys into x86-foo.
-    local board=$(lsbval $lsb CHROMEOS_RELEASE_BOARD |
+    local board=$(lsbval $lsb COREOS_RELEASE_BOARD |
                   cut -d = -f 2 |
                   cut -d - -f 1,2)
     # a copy of the board string with '-' squished to variable-name-safe '_'.
     local boardvar=${board//-/_}
-    channel=$(lsbval $lsb CHROMEOS_RELEASE_TRACK)
+    channel=$(lsbval $lsb COREOS_RELEASE_TRACK)
     # For a canary or dogfood channel, appid maybe a different default value.
     if [ $channel = 'canary-channel' ] || [ $channel = 'dogfood-channel' ]; then
       eval "expected_appid=\"\$expected_appid_${channel%\-channel}\""
     else
       eval "expected_appid=\"\$expected_appid_$boardvar\""
     fi
-    lsbequals $lsb CHROMEOS_RELEASE_APPID "$expected_appid" || testfail=1
+    lsbequals $lsb COREOS_RELEASE_APPID "$expected_appid" || testfail=1
   else # unrecognized board
     testfail=1
   fi

--- a/scripts/image_signing/ensure_secure_kernelparams.sh
+++ b/scripts/image_signing/ensure_secure_kernelparams.sh
@@ -98,7 +98,7 @@ main() {
 
     # Pick the right set of test-expectation data to use. The cuts
     # turn e.g. x86-foo as a well as x86-foo-pvtkeys into x86_foo.
-    local board=$(grep CHROMEOS_RELEASE_BOARD= "$rootfs/etc/lsb-release" | \
+    local board=$(grep COREOS_RELEASE_BOARD= "$rootfs/etc/lsb-release" | \
                   cut -d = -f 2 | cut -d - -f 1,2 --output-delimiter=_)
     eval "required_kparams=(\"\${required_kparams_$board[@]}\")"
     eval "required_kparams_regex=(\"\${required_kparams_regex_$board[@]}\")"

--- a/scripts/image_signing/set_channel.sh
+++ b/scripts/image_signing/set_channel.sh
@@ -30,7 +30,7 @@ main() {
   lsb="${rootfs}/etc/lsb-release"
   mount_image_partition "${image}" 3 "${rootfs}"
   # Get the current channel on the image.
-  local from=$(grep '^CHROMEOS_RELEASE_TRACK=' "${lsb}" | cut -d '=' -f 2)
+  local from=$(grep '^COREOS_RELEASE_TRACK=' "${lsb}" | cut -d '=' -f 2)
   from=${from%"-channel"}
   echo "Current channel is '${from}'. Changing to '${to}'."
 

--- a/scripts/image_signing/set_lsb_release.sh
+++ b/scripts/image_signing/set_lsb_release.sh
@@ -34,9 +34,9 @@ $ $PROG chromiumos_image.bin
 
 Dumps /etc/lsb-release from chromiumos_image.bin to stdout.
 
-$ $PROG chromiumos_image.bin CHROMEOS_RELEASE_DESCRIPTION "New description"
+$ $PROG chromiumos_image.bin COREOS_RELEASE_DESCRIPTION "New description"
 
-Sets the CHROMEOS_RELEASE_DESCRIPTION key's value to "New description"
+Sets the COREOS_RELEASE_DESCRIPTION key's value to "New description"
 in /etc/lsb-release in chromiumos_image.bin, sorts the keys and dumps
 the updated file to stdout.
 


### PR DESCRIPTION
use the COREOS_ variables in /etc/lsb-release
