### PR TITLE
fix(cgpt): Stop compiling cgpt statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -681,7 +681,6 @@ cgpt: ${CGPT}
 ${CGPT_OBJS}: INCLUDES += -Ihost/include
 ${CGPT_OBJS}: CFLAGS += -std=gnu99
 
-${CGPT}: LDFLAGS += -static
 ${CGPT}: LDLIBS += -lblkid -luuid
 
 ${CGPT}: ${CGPT_OBJS} ${HOSTLIB}


### PR DESCRIPTION
Linking to libblkid.a if it was compiled with an older libc is causing
linking issues. Just knock it off and link dynamically like a sane C app.
