### PR TITLE
fix(cgpt): Change the hybrid MBR partition type to FAT32

### DIFF
--- a/cgpt/cgpt_common.c
+++ b/cgpt/cgpt_common.c
@@ -1033,9 +1033,13 @@ static void fill_part(struct legacy_partition *part, int bootable,
   compute_chs(part->l_chs, ending_lba);
   part->num_sect = htole32((uint32_t)(ending_lba - starting_lba + 1));
 
+  /* If the MBR partition is a bootable hybrid partition set the boot
+   * flag and use type 0x0c (FAT32 LBA). Although the partition is
+   * likely to be our EFI System Partition it cannot use it's proper
+   * type (0xef) because pvgrub and grub-0.97 will not recognize it. */
   if (bootable) {
     part->status = 0x80;
-    part->type = 0xef;
+    part->type = 0x0c;
   } else {
     part->status = 0x00;
     part->type = 0xee;


### PR DESCRIPTION
Xen's pvgrub and grub 0.97 on which it is based do not recognize the EFI
partition type 0xef as a FAT filesystem. The "FAT32 LBA" type works.

For reference here is the list of types defined in grub 0.97:

```
#define PC_SLICE_TYPE_HIDDEN_FLAG       0x10
#define PC_SLICE_TYPE_NONE              0
#define PC_SLICE_TYPE_FAT12             1
#define PC_SLICE_TYPE_FAT16_LT32M       4
#define PC_SLICE_TYPE_EXTENDED          5
#define PC_SLICE_TYPE_FAT16_GT32M       6
#define PC_SLICE_TYPE_FAT32             0xb
#define PC_SLICE_TYPE_FAT32_LBA         0xc
#define PC_SLICE_TYPE_FAT16_LBA         0xe
#define PC_SLICE_TYPE_WIN95_EXTENDED    0xf
#define PC_SLICE_TYPE_EZD               0x55
#define PC_SLICE_TYPE_MINIX             0x80
#define PC_SLICE_TYPE_LINUX_MINIX       0x81
#define PC_SLICE_TYPE_EXT2FS            0x83
#define PC_SLICE_TYPE_LINUX_EXTENDED    0x85
#define PC_SLICE_TYPE_VSTAFS            0x9e
#define PC_SLICE_TYPE_DELL_UTIL         0xde
#define PC_SLICE_TYPE_LINUX_RAID        0xfd
```
