### PR TITLE
build: remove -fuse-ld=bfd from LDFLAGS, unrecognized option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -803,11 +803,6 @@ ${BUILD}/%.o: %.cc
 # GBB utility needs C++ linker. TODO: It shouldn't.
 ${BUILD}/utility/gbb_utility: LD = ${CXX}
 
-# Because we play some clever linker script games to add new commands without
-# changing any header files, futility must be linked with ld.bfd, not gold.
-${FUTIL_BIN}: LDFLAGS += -fuse-ld=bfd
-${FUTIL_STATIC_BIN}: LDFLAGS += -fuse-ld=bfd
-
 # Some utilities need external crypto functions
 ${BUILD}/utility/dumpRSAPublicKey: LDLIBS += ${CRYPTO_LIBS}
 ${BUILD}/utility/pad_digest_utility: LDLIBS += ${CRYPTO_LIBS}


### PR DESCRIPTION
This option was improperly accepted previously despite being
unsupported. With GCC 4.7.x it is being explicitly rejected.
It isn't even needed because we do not use gold by default.
