### PR TITLE
make cgpt deal with cciss devices

### DIFF
--- a/cgpt/cgpt_common.c
+++ b/cgpt/cgpt_common.c
@@ -1114,10 +1114,11 @@ static const char *devdirs[] = { "/dev", "/devices", "/devfs", 0 };
 // This is copied from the logic in the linux utility 'findfs', although that
 // does more exhaustive searching.
 char *IsWholeDev(const char *basename) {
-  int i;
+  int i,j,len;
   struct stat statbuf;
   static char pathname[BUFSIZE];        // we'll return this.
   char tmpname[BUFSIZE];
+  char tbasename[BUFSIZE];
 
   // It should be a block device under /dev/,
   for (i = 0; devdirs[i]; i++) {
@@ -1130,7 +1131,14 @@ char *IsWholeDev(const char *basename) {
       continue;
 
     // It should have a symlink called /sys/block/*/device
-    snprintf(tmpname, BUFSIZE, "%s/%s/device", SYS_BLOCK_DIR, basename);
+    // but devices containing '/' (like cciss ones) must
+    // be changed to use "!" instead
+    len = strlen(basename);
+    for (j = 0; j < len && j < BUFSIZE - 1; j++) {
+        tbasename[j] = basename[j] == '/' ? '!' : basename[j];
+    }
+    tbasename[j] = 0;
+    snprintf(tmpname, BUFSIZE, "%s/%s/device", SYS_BLOCK_DIR, tbasename);
 
     if (0 != lstat(tmpname, &statbuf))
       continue;


### PR DESCRIPTION
Hi,

when trying to install coreos on HP DL360 G5 servers, I discovered that cgpt couldn't manage cciss devices, because these devices are like:
/dev/cciss/c0d0....

cgpt, when reading /proc/partitions, tries to challenge the device name with a file in /sys/block. Unfortunately this last file path is different from the device name, because of the '/', which is converted to a '!'.

This PR adds the support to such devices (plus it removes a buffer overrun possibility).

Hope you will merge it,
## 

rémi
