### PR TITLE
cgpt: fix simplified hybrid MBR

### DIFF
--- a/cgpt/cgpt_common.c
+++ b/cgpt/cgpt_common.c
@@ -1097,9 +1097,8 @@ void UpdatePMBR(struct drive *drive, int secondary) {
     // may be issues when there are two partitions of type 0xee (EFI).
     fill_part(&drive->pmbr.part[0], MBR_BOOTABLE,
               entry->starting_lba, entry->ending_lba);
-    // Create protective partition to cover the remaining space.
-    if (entry->ending_lba < max)
-      fill_part(&drive->pmbr.part[1], MBR_HYBRID, entry->ending_lba + 1, max);
+    // Create protective partition to cover the GPT table.
+    fill_part(&drive->pmbr.part[1], MBR_HYBRID, 1, entry->starting_lba - 1);
     return;
   }
 


### PR DESCRIPTION
Commit dbf566e2 switched from creating a hybrid MBR with two protective
partitions to just one, opting to cover the end of the disk since that
included the real data. However it turns out the hybrid MBR is not
probably detected as such by Linux in this case, the protective
partition needs to cover the beginning of the disk instead.
