### PR TITLE
e2size: add tool to measure ext* filesystems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq uuid-dev gdisk libblkid-dev
+ - sudo apt-get install -qq uuid-dev gdisk libblkid-dev e2fslibs-dev
 script: |
     ./autogen.sh
     mkdir build

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ cgpt_SOURCES = \
 cgpt_LDADD = $(BLKID_LIBS) $(UUID_LIBS)
 
 e2size_SOURCES = src/e2size/e2size.c
-e2size_CFLAGS = -lext2fs
+e2size_LDADD = $(EXT2FS_LIBS)
 
 check_PROGRAMS = cgptlib_test \
 		 utility_string_tests \

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ AM_CFLAGS = -Wall -Werror \
 	    -fvisibility=hidden \
 	    -std=gnu99
 
-bin_PROGRAMS = cgpt
+bin_PROGRAMS = cgpt e2size
 
 cgpt_SOURCES = \
 	src/cgpt/blkid_utils.c \
@@ -45,6 +45,9 @@ cgpt_SOURCES = \
 	src/firmware/lib/utility_string.c \
 	src/firmware/stub/utility_stub.c
 cgpt_LDADD = $(BLKID_LIBS) $(UUID_LIBS)
+
+e2size_SOURCES = src/e2size/e2size.c
+e2size_CFLAGS = -lext2fs
 
 check_PROGRAMS = cgptlib_test \
 		 utility_string_tests \

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_PROG_CC
 # Checks for libraries.
 PKG_CHECK_MODULES([BLKID], [blkid])
 PKG_CHECK_MODULES([UUID], [uuid])
+PKG_CHECK_MODULES([EXT2FS], [ext2fs])
 
 # Checks for header files.
 

--- a/src/e2size/e2size.c
+++ b/src/e2size/e2size.c
@@ -1,0 +1,46 @@
+/* Copyright (c) 2015 The CoreOS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ *
+ * Finds the size of an ext{2,3,4} filesystem located at the beginning of a given device.
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+#include <error.h>
+#include <ext2fs/ext2fs.h>
+
+static void usage() {
+	fprintf(stderr, "Usage: e2size <device>\n");
+}
+
+int main(int argc, char *argv[]) {
+	ext2_filsys fs;
+	errcode_t err;
+	uint64_t fs_size = 0;
+	int retc = 1;
+
+	if (argc != 2) {
+		usage();
+		goto out;
+	}
+
+	err = ext2fs_open(argv[1], 0, 0, 0, unix_io_manager, &fs);
+
+	if (err != 0) {
+		fprintf(stderr, "%s\n", strerror(errno));
+		goto out;
+	}
+
+	fs_size = ext2fs_blocks_count(fs->super) * fs->blocksize;
+
+	printf("%" PRIu64 "\n", fs_size);
+
+	retc = 0;
+
+out:
+	if ( fs != NULL ) {
+		ext2fs_close(fs);
+	}
+	return retc;
+}


### PR DESCRIPTION
This is a very simple tool to give us the size of the filesystem on USR so that `veritysetup` knows where to look for the metadata block.