### PR TITLE
cgpt: add guid flag

### DIFF
--- a/src/cgpt/cmd_create.c
+++ b/src/cgpt/cmd_create.c
@@ -16,6 +16,7 @@ static void Usage(void)
          "  -c           Create disk image file if needed. Requires -s\n"
          "  -s NUM       Minimum disk sectors, extends image files\n"
          "  -z           Zero the sectors of the GPT table and entries\n"
+         "  -g GUID      The desired disk GUID\n"
          "\n", progname);
 }
 
@@ -28,7 +29,7 @@ int cmd_create(int argc, char *argv[]) {
   char *e = 0;
 
   opterr = 0;                     // quiet, you
-  while ((c=getopt(argc, argv, ":hcs:z")) != -1)
+  while ((c=getopt(argc, argv, ":hcs:zg:")) != -1)
   {
     switch (c)
     {
@@ -44,6 +45,9 @@ int cmd_create(int argc, char *argv[]) {
         Error("invalid argument to -%c: \"%s\"\n", c, optarg);
         errorcnt++;
       }
+      break;
+    case 'g':
+      params.drive_guid = optarg;
       break;
 
     case 'h':

--- a/src/host/include/cgpt_params.h
+++ b/src/host/include/cgpt_params.h
@@ -16,6 +16,7 @@ enum {
 
 typedef struct CgptCreateParams {
   char *drive_name;
+  char *drive_guid;
   int zap;
   int create;
   uint64_t min_size;

--- a/tests/run_cgpt_tests.sh
+++ b/tests/run_cgpt_tests.sh
@@ -157,6 +157,17 @@ else
 fi
 
 
+if [[ -n "$SGDISK" ]]; then
+    echo "Test cgpt disk GUID"
+    GUID='01234567-89AB-CDEF-0123-456789ABCDEF'
+    $CGPT create -s 1000 -g ${GUID} ${DEV} || error
+    [[ $($SGDISK --print ${DEV} | \
+         gawk -F': ' '/Disk identifier/ { print $2 }') == ${GUID} ]] || error
+else
+    echo "Skipping cpgt disk GUID test because sgdisk wasn't found"
+fi
+
+
 echo "Create an empty file to use as the device..."
 NUM_SECTORS=1000
 rm -f ${DEV}


### PR DESCRIPTION
This flag (-g) allows the caller to specify the disk GUID instead of
having one generated.