### PR TITLE
cgpt: include ending_lba sector in the entry size

### DIFF
--- a/src/cgpt/cgpt_resize.c
+++ b/src/cgpt/cgpt_resize.c
@@ -124,7 +124,7 @@ static int resize_partition(CgptResizeParams *params, blkid_dev dev) {
 
   // Update and test partition table in memory
   entry->ending_lba = last_free_lba;
-  entry_size_lba = entry->ending_lba - entry->starting_lba;
+  entry_size_lba = entry->ending_lba - entry->starting_lba + 1;
   UpdateAllEntries(&drive);
   gpt_retval = CheckEntries((GptEntry*)drive.gpt.primary_entries,
                             (GptHeader*)drive.gpt.primary_header);


### PR DESCRIPTION
AFAICT the ending_lba delimits the end inclusively, hence we need to +1
in computing the length from (ending_lba - starting_lba).

Fixes https://github.com/coreos/bugs/issues/1527