### PR TITLE
build: disable static by default, fix librootdev symbol export

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ loopy_LDADD = $(MNT_LIBS)
 
 librootdev_la_SOURCES = src/rootdev/rootdev.c
 librootdev_la_CFLAGS = -Wall -Werror -std=gnu99
-librootdev_la_LDFLAGS = -export-symbols-regex '^rootdev_' \
+librootdev_la_LDFLAGS = -export-symbols-regex '^rootdev' \
 			-version-info 1:0:0
 
 rootdev_SOURCES = src/rootdev/main.c

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_SYS_LARGEFILE
 AM_INIT_AUTOMAKE([foreign 1.11 -Wall -Wno-portability silent-rules subdir-objects])
 AM_SILENT_RULES([yes])
 
-LT_INIT
+LT_INIT([disable-static])
 
 # Checks for programs.
 AC_PROG_CC


### PR DESCRIPTION
Don't need to install librootdev.a and there is a function named simply `rootdev` so `^rootdev_` was excluding it.