### PR TITLE
Updated to support changes in glibc

### DIFF
--- a/src/cgpt/blkid_utils.c
+++ b/src/cgpt/blkid_utils.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 
 #include "cgpt.h"

--- a/src/rootdev/main.c
+++ b/src/rootdev/main.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
 

--- a/src/rootdev/rootdev.c
+++ b/src/rootdev/rootdev.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
 
@@ -92,7 +93,6 @@ static int match_sysfs_device(char *name, size_t name_len,
   size_t basedir_len;
   DIR *dirp = NULL;
   struct dirent *entry = NULL;
-  struct dirent *next = NULL;
   char *working_path = NULL;
   long working_path_size = 0;
 
@@ -138,7 +138,7 @@ static int match_sysfs_device(char *name, size_t name_len,
     return found;
   }
 
-  while (readdir_r(dirp, entry, &next) == 0 && next) {
+  while ((entry = readdir(dirp)) != NULL) {
     size_t candidate_len = strlen(entry->d_name);
     size_t path_len = 0;
     dev_t found_devt = 0;


### PR DESCRIPTION
This applies a few fixes for compatibility with glibc 2.24 and 2.25. We're
building seismograph on some other Gentoo systems to use cgpt and hit this issue
recently after a full rebuild since upstream Gentoo recently marked glibc 2.25
stable.

glibc 2.24 added errors when use `makedev`, `major`, `minor` when included from
`sys/types.h`. The definitions have been moved to `sys/macros.h` and are
resolevd just by including it.

glibc 2.24 deprecated `readdir_r`, and glibc 2.25 made its use an error. glibc
implements `readdir` as thread-safe and recommends it over `readdir_r.